### PR TITLE
[CHI-383] Added support of alert-title attribute for alert CE

### DIFF
--- a/cypress/integration/chi-custom-elements/alert.spec.js
+++ b/cypress/integration/chi-custom-elements/alert.spec.js
@@ -1,23 +1,45 @@
 describe('Alert', () => {
   const alertBannerSelectors = [
-    'alert-banner-default-success',
-    'alert-banner-default-warning',
-    'alert-banner-default-warning-center',
-    'alert-banner-large-success',
-    'alert-banner-large-success-dismiss',
-    'alert-banner-large-muted-icon-center'
+    'alert-banner-success-default',
+    'alert-banner-center-success-default',
+    'alert-banner-dismissible-success-default',
+    'alert-banner-borderless-success-default',
+    'alert-banner-rounded-success-default',
+    'alert-banner-titled-success-default',
+    'alert-banner-success-sm',
+    'alert-banner-center-success-sm',
+    'alert-banner-dismissible-success-sm',
+    'alert-banner-borderless-success-sm',
+    'alert-banner-rounded-success-sm',
+    'alert-banner-titled-success-sm',
+    'alert-banner-success-lg',
+    'alert-banner-center-success-lg',
+    'alert-banner-dismissible-success-lg',
+    'alert-banner-borderless-success-lg',
+    'alert-banner-rounded-success-lg',
+    'alert-banner-titled-success-lg'
   ];
 
   const alertBubbleSelectors = [
-    'alert-bubble-default-success',
-    'alert-bubble-default-warning',
-    'alert-bubble-large-success',
-    'alert-bubble-large-success-dismiss',
+    'alert-bubble-success-default',
+    'alert-bubble-center-success-default',
+    'alert-bubble-dismissible-success-default',
+    'alert-bubble-titled-success-default',
+    'alert-bubble-actionable-success-default',
+    'alert-bubble-success-sm',
+    'alert-bubble-center-success-sm',
+    'alert-bubble-dismissible-success-sm',
+    'alert-bubble-titled-success-sm',
+    'alert-bubble-actionable-success-sm',
+    'alert-bubble-success-lg',
+    'alert-bubble-center-success-lg',
+    'alert-bubble-dismissible-success-lg',
+    'alert-bubble-titled-success-lg',
+    'alert-bubble-actionable-success-lg'
   ];
 
   const alertAssertion = (el, value) => {
-    cy.get(el)
-      .should('have.class', value);
+    cy.get(el).should('have.class', value);
   };
 
   describe('Alert Bubble', () => {
@@ -36,11 +58,11 @@ describe('Alert', () => {
     });
 
     it('Alert bubble should be included in the custom element', () => {
-      cy.get('@alert-bubble-default-success');
+      cy.get('@alert-bubble-success-default');
     });
 
     it('Alert bubble state have appropriate class', () => {
-      alertAssertion('@alert-bubble-default-warning', '-warning');
+      alertAssertion('@alert-bubble-success-default', '-success');
     });
   });
 
@@ -60,19 +82,19 @@ describe('Alert', () => {
     });
 
     it('Alert banner should be included in the custom element', () => {
-      cy.get('@alert-banner-default-success');
+      cy.get('@alert-banner-success-default');
     });
 
     it('Alert banner state have appropriate class', () => {
-      alertAssertion('@alert-banner-default-warning', '-warning');
+      alertAssertion('@alert-banner-success-default', '-success');
     });
 
     it('Alert banner should have appropriate class for size', () => {
-      alertAssertion('@alert-banner-large-success', '-lg');
+      alertAssertion('@alert-banner-success-lg', '-lg');
     });
 
     it('Alert banner is dismissible and renders X button', () => {
-      cy.get('@alert-banner-large-success-dismiss')
+      cy.get('@alert-banner-dismissible-success-lg')
         .should('have.class', '-dismiss')
         .children()
         .last()
@@ -82,14 +104,11 @@ describe('Alert', () => {
     });
 
     it('Alert banner is centered', () => {
-      alertAssertion('@alert-banner-default-warning-center', '-center');
+      alertAssertion('@alert-banner-center-success-default', '-center');
     });
 
     it('Alert banner has icons displayed', () => {
-      cy.get('@alert-banner-large-muted-icon-center')
-        .should('have.class', '-center')
-        .children()
-        .first()
+      cy.get('@alert-banner-success-default')
         .children()
         .first()
         .should('match', 'chi-icon');
@@ -98,11 +117,11 @@ describe('Alert', () => {
     it('Alert banner dismiss button should trigger appropriate event', () => {
       const spy = cy.spy();
 
-      cy.get('body').then((el) => {
+      cy.get('body').then(el => {
         el.on('dismissAlert', spy);
       });
 
-      cy.get('@alert-banner-large-success-dismiss')
+      cy.get('@alert-banner-dismissible-success-default')
         .children()
         .last()
         .should('match', 'chi-button')
@@ -119,11 +138,10 @@ describe('Alert', () => {
     });
 
     it('Alert toast should be included in the custom element', () => {
-      cy.get('[data-cy="alert-toast-success"]', { timeout: 5000 })
+      cy.get('[data-cy="alert-toast-success-default"]', { timeout: 5000 })
         .should('have.class', 'hydrated')
         .children()
         .should('match', 'div.m-alert.-toast');
     });
   });
-
 });

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2019-11-12T16:12:33",
+  "timestamp": "2019-11-13T14:35:12",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",
@@ -15,14 +15,35 @@
       "usage": {},
       "props": [
         {
+          "name": "alert-title",
+          "type": "string",
+          "mutable": false,
+          "attr": "alert-title",
+          "reflectToAttr": true,
+          "docs": "to define alert title.",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
           "name": "borderless",
           "type": "boolean",
           "mutable": false,
           "attr": "borderless",
           "reflectToAttr": true,
-          "docs": "to get rid of the border-bottom of BANNER alerts.",
+          "docs": "to get rid of the border-bottom of Banner alerts.",
           "docsTags": [],
           "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
           "optional": false,
           "required": false
         },
@@ -84,6 +105,11 @@
           "reflectToAttr": true,
           "docs": "to avoid necessity of adding <chi-icon> to alert markup.",
           "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
           "optional": false,
           "required": false
         },
@@ -110,9 +136,14 @@
           "mutable": false,
           "attr": "rounded",
           "reflectToAttr": true,
-          "docs": "to make BANNER alert corners rounded.",
+          "docs": "to make Banner alert corners rounded.",
           "docsTags": [],
           "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
           "optional": false,
           "required": false
         },
@@ -124,7 +155,7 @@
           "reflectToAttr": true,
           "docs": "to set alert size { sm, md, lg }.",
           "docsTags": [],
-          "default": "'md'",
+          "default": "''",
           "values": [
             {
               "type": "string"
@@ -167,10 +198,12 @@
       "slots": [],
       "dependents": [],
       "dependencies": [
+        "chi-icon",
         "chi-button"
       ],
       "dependencyGraph": {
         "chi-alert": [
+          "chi-icon",
           "chi-button"
         ],
         "chi-button": [
@@ -284,6 +317,22 @@
       "usage": {},
       "props": [
         {
+          "name": "color",
+          "type": "string",
+          "mutable": false,
+          "attr": "color",
+          "reflectToAttr": true,
+          "docs": "to set brand color { black, white, inverse }.",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
           "name": "size",
           "type": "string",
           "mutable": false,
@@ -300,12 +349,12 @@
           "required": false
         },
         {
-          "name": "color",
+          "name": "type",
           "type": "string",
           "mutable": false,
-          "attr": "color",
+          "attr": "type",
           "reflectToAttr": true,
-          "docs": "to set brand color { black, white, inverse }.",
+          "docs": "to set brand type { black, white, inverse }.",
           "docsTags": [],
           "values": [
             {
@@ -520,30 +569,6 @@
       "usage": {},
       "props": [
         {
-          "name": "active",
-          "type": "boolean",
-          "mutable": true,
-          "attr": "active",
-          "reflectToAttr": true,
-          "docs": "Indicates whether the dropdown calendar is open or closed",
-          "docsTags": [],
-          "default": "false",
-          "optional": false,
-          "required": false
-        },
-        {
-          "name": "disabled",
-          "type": "boolean",
-          "mutable": false,
-          "attr": "disabled",
-          "reflectToAttr": true,
-          "docs": "to disable chi-date-picker.",
-          "docsTags": [],
-          "default": "false",
-          "optional": false,
-          "required": false
-        },
-        {
           "name": "format",
           "type": "string",
           "mutable": false,
@@ -696,6 +721,23 @@
           "attr": "active",
           "reflectToAttr": true,
           "docs": "Indicates whether the dropdown calendar is open or closed",
+          "docsTags": [],
+          "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "mutable": false,
+          "attr": "disabled",
+          "reflectToAttr": true,
+          "docs": "to disable chi-date-picker.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -1139,6 +1181,11 @@
           "reflectToAttr": true,
           "docs": "OPTIONAL classes",
           "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
           "optional": false,
           "required": false
         },
@@ -1180,6 +1227,7 @@
       "styles": [],
       "slots": [],
       "dependents": [
+        "chi-alert",
         "chi-button",
         "chi-date",
         "chi-drawer",
@@ -1187,6 +1235,9 @@
       ],
       "dependencies": [],
       "dependencyGraph": {
+        "chi-alert": [
+          "chi-icon"
+        ],
         "chi-button": [
           "chi-icon"
         ],

--- a/src/custom-elements/src/components/alert/alert.tsx
+++ b/src/custom-elements/src/components/alert/alert.tsx
@@ -36,12 +36,12 @@ export class Alert {
   @Prop({ reflectToAttr: true }) size = '';
 
   /**
-   *  to get rid of the border-bottom of BANNER alerts.
+   *  to get rid of the border-bottom of Banner alerts.
    */
   @Prop({ reflectToAttr: true }) borderless = false;
 
   /**
-   *  to make BANNER alert corners rounded.
+   *  to make Banner alert corners rounded.
    */
   @Prop({ reflectToAttr: true }) rounded = false;
 
@@ -54,6 +54,11 @@ export class Alert {
    *  to make the alert dismissible.
    */
   @Prop({ reflectToAttr: true }) dismissible = false;
+
+  /**
+   *  to define alert title.
+   */
+  @Prop({ reflectToAttr: true }) alertTitle: string;
 
   /**
    *  custom event when trying to dismiss an alert.
@@ -96,6 +101,8 @@ export class Alert {
 
   render() {
     const chiIcon = <chi-icon icon={this.icon} color={this.color} extraClass="m-alert__icon"></chi-icon>;
+    const alertTitle = this.alertTitle ? <p class="m-alert__title">{this.alertTitle}</p> : '';
+
     return (
       <div class={`m-alert
         ${this.type ? `-${this.type}` : ''}
@@ -108,8 +115,11 @@ export class Alert {
         role="alert"
       >
         {this.icon && chiIcon}
-        <slot></slot>
-        {(this.dismissible || this.type === 'toast') && <chi-button extraClass="m-alert__dismiss-button" type="close" onChiClick={() => this._dismissAlert()}/>}
+        <div class="m-alert__content">
+          {this.alertTitle && alertTitle}
+          <slot></slot>
+        </div>
+        {(this.dismissible || this.type === 'toast') && <chi-button extraClass="m-alert__dismiss-button" type="close" onChiClick={() => this._dismissAlert()} />}
       </div>
     );
   }

--- a/src/website/views/custom-elements/alert.pug
+++ b/src/website/views/custom-elements/alert.pug
@@ -358,22 +358,17 @@ p.-text
   | While <code>m-alert__actions</code> can be added to any Alert, alert actions are best suited for <code>lg</code> default or Titled alerts.
 .example.-mb--3
   .-p--1.-bg--grey-20
-    chi-alert.-m--2(type='banner', icon='circle-info', size='lg', dismissible)
-      .m-alert__content
-        p.m-alert__title Base
-        p.m-alert__text This is a large dismissible alert
-        div.m-alert__actions
-          chi-button(color='dark', variant='outline', size='lg') Secondary action
-          chi-button(color='primary', size='lg') Primary action
+    chi-alert.-m--2(type='banner', icon='circle-info', size='lg', alert-title="Base", dismissible)
+      p.m-alert__text This is a large dismissible alert
+      div.m-alert__actions
+        chi-button(color='dark', variant='outline', size='lg') Secondary action
+        chi-button(color='primary', size='lg') Primary action
   :code(lang="html")
-    <chi-alert type="banner" icon="circle-info" size="lg" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Base</p>
-        <p class="m-alert__text">This is a large dismissible alert</p>
-        <div class="m-alert__actions">
-          <chi-button color="dark" variant="outline" size="lg">Secondary action</chi-button>
-          <chi-button color="primary" size="lg">Primary action</chi-button>
-        </div>
+    <chi-alert type="banner" icon="circle-info" size="lg" alert-title="Base" dismissible>
+      <p class="m-alert__text">This is a large dismissible alert</p>
+      <div class="m-alert__actions">
+        <chi-button color="dark" variant="outline" size="lg">Secondary action</chi-button>
+        <chi-button color="primary" size="lg">Primary action</chi-button>
       </div>
     </chi-alert>
 

--- a/src/website/views/custom-elements/alert.pug
+++ b/src/website/views/custom-elements/alert.pug
@@ -22,48 +22,34 @@ h4 Default
 .example.-mb--3
   .-p--1
     chi-alert(icon='circle-info').-m--2
-      .m-alert__content
-        p.m-alert__text This is a base alert
+      p.m-alert__text This is a base alert
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       chi-alert.-m--2(color=type, icon=val)
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
     <chi-alert icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
     <chi-alert color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
     <chi-alert color="danger" icon="circle-warning">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
     <chi-alert color="warning" icon="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
     <chi-alert color="info" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
     <chi-alert color="muted" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Centered
@@ -74,69 +60,46 @@ p.-text
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(color='danger', icon='circle-warning', center)
-      .m-alert__content
-        p.m-alert__text= 'This is a centered danger alert'
+      p.m-alert__text= 'This is a centered danger alert'
   :code(lang="html")
     <chi-alert color="danger" icon="circle-warning" center>
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a centered danger alert</p>
-      </div>
+      <p class="m-alert__text">This is a centered danger alert</p>
     </chi-alert>
 
 h4 Titled
+p.-text
+  | Use the attribute <code>alert-title=""</code> to have alert title above the alert text.
 .example.-mb--3
   .-p--1
-    chi-alert(icon='circle-info').-m--2
-      .m-alert__content
-        p.m-alert__title Base
-        p.m-alert__text This is a base alert
+    chi-alert(icon='circle-info', alert-title="Base").-m--2
+      p.m-alert__text This is a base alert asd
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val)
-        .m-alert__content
-          p.m-alert__title= type
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, alert-title=type)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
-    <chi-alert icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Base</p>
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+    <chi-alert icon="circle-info" alert-title="Base">
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
-    <chi-alert color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert color="success" icon="circle-check" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
-    <chi-alert color="danger" icon="circle-warning">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Danger</p>
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+    <chi-alert color="danger" icon="circle-warning" alert-title="Danger">
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
-    <chi-alert color="warning" icon="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+    <chi-alert color="warning" icon="warning" alert-title="Warning">
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
-    <chi-alert color="info" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Info</p>
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+    <chi-alert color="info" icon="circle-info" alert-title="Info">
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
-    <chi-alert color="muted" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Muted</p>
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+    <chi-alert color="muted" icon="circle-info" alert-title="Muted">
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Sizes
@@ -145,67 +108,43 @@ h4 Sizes
   .-p--1
     p.-text--bold.-ml--2 -sm
     chi-alert.-m--2(color='success', icon='circle-check', size='sm')
-      .m-alert__content
-        p.m-alert__text This is a small success alert
-    chi-alert.-m--2(color='success', icon='circle-check', size='sm')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a small success alert
+      p.m-alert__text This is a small success alert
+    chi-alert.-m--2(color='success', icon='circle-check', size='sm', alert-title="Success")
+      p.m-alert__text This is a small success alert
     p.-text--bold.-ml--2 -md (default)
     chi-alert.-m--2(color='success', icon='circle-check')
-      .m-alert__content
-        p.m-alert__text This is a success alert
-    chi-alert.-m--2(color='success', icon='circle-check')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a success alert
+      p.m-alert__text This is a success alert
+    chi-alert.-m--2(color='success', icon='circle-check', alert-title="Success")
+      p.m-alert__text This is a success alert
     p.-text--bold.-ml--2 -lg
     chi-alert.-m--2(color='success', icon='circle-check', size='lg')
-      .m-alert__content
-        p.m-alert__text This is a large success alert
-    chi-alert.-m--2(color='success', icon='circle-check', size='lg')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a large success alert
+      p.m-alert__text This is a large success alert
+    chi-alert.-m--2(color='success', icon='circle-check', size='lg', alert-title="Success")
+      p.m-alert__text This is a large success alert
   :code(lang="html")
     <!-- Small -->
     <chi-alert color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Small Titled -->
-    <chi-alert color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+    <chi-alert color="success" icon="circle-check" size="sm" alert-title="Success">
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Medium -->
     <chi-alert color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Medium Titled -->
-    <chi-alert color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert color="success" icon="circle-check" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Large -->
     <chi-alert color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
     <!-- Large Titled -->
-    <chi-alert color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+    <chi-alert color="success" icon="circle-check" size="lg" alert-title="Success">
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
 
 h4 Dismissible
@@ -214,36 +153,23 @@ p.-text
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(color='warning', icon='warning', dismissible)
-      .m-alert__content
-        p.m-alert__text This is a dismissible warning alert
-    chi-alert.-m--2(color='warning', icon='warning', dismissible)
-      .m-alert__content
-        p.m-alert__title Warning
-        p.m-alert__text This is a dismissible warning alert
-    chi-alert.-m--2(color='warning', icon='warning', size='lg', dismissible)
-      .m-alert__content
-        p.m-alert__title Warning
-        p.m-alert__text This is a large dismissible warning alert
+      p.m-alert__text This is a dismissible warning alert
+    chi-alert.-m--2(color='warning', icon='warning', dismissible, alert-title="Warning")
+      p.m-alert__text This is a dismissible warning alert
+    chi-alert.-m--2(color='warning', icon='warning', size='lg', dismissible, alert-title="Warning")
+      p.m-alert__text This is a large dismissible warning alert
   :code(lang="html")
     <!-- Dismissible -->
     <chi-alert color="warning" icon="warning" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a dismissible warning alert</p>
-      </div>
+      <p class="m-alert__text">This is a dismissible warning alert</p>
     </chi-alert>
     <!-- Dismissible Titled -->
-    <chi-alert color="warning" icon="warning" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a dismissible warning alert</p>
-      </div>
+    <chi-alert color="warning" icon="warning" alert-title="Warning" dismissible>
+      <p class="m-alert__text">This is a dismissible warning alert</p>
     </chi-alert>
     <!-- Large Dismissible Titled -->
-    <chi-alert color="warning" icon="warning" size="lg" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a large dismissible warning alert</p>
-      </div>
+    <chi-alert color="warning" icon="warning" size="lg" alert-title="Warning" dismissible>
+      <p class="m-alert__text">This is a large dismissible warning alert</p>
     </chi-alert>
 
 h4 Actionable
@@ -251,22 +177,17 @@ p.-text
   | While <code>m-alert__actions</code> can be added to any Alert, alert actions are best suited for <code>lg</code> default or Titled alerts.
 .example.-mb--3
   .-p--1
-    chi-alert.-m--2(color='success', icon='circle-check', size='lg', dismissible)
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a large dismissible success alert
-        div.m-alert__actions
-          chi-button(color='dark', variant='outline', size='lg') Secondary action
-          chi-button(color='primary', size='lg') Primary action
+    chi-alert.-m--2(color='success', icon='circle-check', size='lg', alert-title="Success", dismissible)
+      p.m-alert__text This is a large dismissible success alert
+      div.m-alert__actions
+        chi-button(color='dark', variant='outline', size='lg') Secondary action
+        chi-button(color='primary', size='lg') Primary action
   :code(lang="html")
-    <chi-alert color="success" icon="circle-check" size="lg" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a large dismissible success alert</p>
-        <div class="m-alert__actions">
-          <chi-button color="dark" variant="outline" size="lg">Secondary action</chi-button>
-          <chi-button color="primary" size="lg">Primary action</chi-button>
-        </div>
+    <chi-alert color="success" icon="circle-check" size="lg" alert-title="Success" dismissible>
+      <p class="m-alert__text">This is a large dismissible success alert</p>
+      <div class="m-alert__actions">
+        <chi-button color="dark" variant="outline" size="lg">Secondary action</chi-button>
+        <chi-button color="primary" size="lg">Primary action</chi-button>
       </div>
     </chi-alert>
 
@@ -284,48 +205,34 @@ h4 Default
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(type='banner', icon='circle-info')
-      .m-alert__content
-        p.m-alert__text This is a base alert
+      p.m-alert__text This is a base alert
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       chi-alert.-m--2(color=type, icon=val, type='banner')
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
     <chi-alert type="banner" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
     <chi-alert type="banner" icon="circle-check" color="success">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
     <chi-alert type="banner" icon="circle-warning" color="danger">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
     <chi-alert type="banner" icon="warning" color="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
     <chi-alert type="banner" icon="circle-info" color="info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
     <chi-alert type="banner" icon="circle-info" color="muted">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Centered
@@ -336,69 +243,44 @@ p.-text
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(type='banner', icon='circle-warning', color='danger', center)
-      .m-alert__content
-        p.m-alert__text= 'This is a centered danger alert'
+      p.m-alert__text= 'This is a centered danger alert'
   :code(lang="html")
     <chi-alert type="banner" icon="circle-warning" color="danger" center>
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a centered danger alert</p>
-      </div>
+      <p class="m-alert__text">This is a centered danger alert</p>
     </chi-alert>
 
 h4 Titled
 .example.-mb--3
   .-p--1
-    chi-alert.-m--2(type='banner', icon='circle-info')
-      .m-alert__content
-        p.m-alert__title Base
-        p.m-alert__text This is a base alert
+    chi-alert.-m--2(type='banner', icon='circle-info', alert-title="Base")
+      p.m-alert__text This is a base alert
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, type='banner', icon=val)
-        .m-alert__content
-          p.m-alert__title= type
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+      chi-alert.-m--2(color=type, type='banner', icon=val, alert-title=type)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
-    <chi-alert type="banner" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Base</p>
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+    <chi-alert type="banner" icon="circle-info" alert-title="Base">
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
-    <chi-alert type="banner" icon="circle-check" color="success">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert type="banner" icon="circle-check" color="success" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
-    <chi-alert type="banner" icon="circle-warning" color="danger">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Danger</p>
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+    <chi-alert type="banner" icon="circle-warning" color="danger" alert-title="Danger">
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
-    <chi-alert type="banner" icon="warning" color="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+    <chi-alert type="banner" icon="warning" color="warning" alert-title="Warning">
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
-    <chi-alert type="banner" icon="circle-info" color="info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Info</p>
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+    <chi-alert type="banner" icon="circle-info" color="info" alert-title="Info">
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
-    <chi-alert type="banner" icon="circle-info" color="muted">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Muted</p>
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+    <chi-alert type="banner" icon="circle-info" color="muted" alert-title="Muted">
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Sizes
@@ -407,67 +289,43 @@ h4 Sizes
   .-p--1
     p.-text--bold.-ml--2 -sm
     chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='sm')
-      .m-alert__content
-        p.m-alert__text This is a small success alert
-    chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='sm')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a small success alert
+      p.m-alert__text This is a small success alert
+    chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='sm', alert-title="Success")
+      p.m-alert__text This is a small success alert
     p.-text--bold.-ml--2 -md (default)
     chi-alert.-m--2(type='banner', icon='circle-check', color='success')
-      .m-alert__content
-        p.m-alert__text This is a success alert
-    chi-alert.-m--2(type='banner', icon='circle-check', color='success')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a success alert
+      p.m-alert__text This is a success alert
+    chi-alert.-m--2(type='banner', icon='circle-check', color='success', alert-title="Success")
+      p.m-alert__text This is a success alert
     p.-text--bold.-ml--2 -lg
     chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='lg')
-      .m-alert__content
-        p.m-alert__text This is a large success alert
-    chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='lg')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a large success alert
+      p.m-alert__text This is a large success alert
+    chi-alert.-m--2(type='banner', icon='circle-check', color='success', size='lg', alert-title="Success")
+      p.m-alert__text This is a large success alert
   :code(lang="html")
     <!-- Small -->
     <chi-alert type="banner" color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Small Titled -->
-    <chi-alert type="banner" color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+    <chi-alert type="banner" color="success" icon="circle-check" size="sm" alert-title="Success">
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Medium -->
     <chi-alert type="banner" color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Medium Titled -->
-    <chi-alert type="banner" color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert type="banner" color="success" icon="circle-check" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Large -->
     <chi-alert type="banner" color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
     <!-- Large Titled -->
-    <chi-alert type="banner" color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+    <chi-alert type="banner" color="success" icon="circle-check" size="lg" alert="Success">
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
 
 h4 Dismissible
@@ -476,36 +334,23 @@ p.-text
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(type='banner', icon='warning', color='warning', dismissible)
-      .m-alert__content
-        p.m-alert__text This is a dismissible warning alert
-    chi-alert.-m--2(type='banner', color='warning', icon='warning', dismissible)
-      .m-alert__content
-        p.m-alert__title Warning
-        p.m-alert__text This is a dismissible warning alert
-    chi-alert.-m--2(type='banner', color='warning', icon='warning', size='lg', dismissible)
-      .m-alert__content
-        p.m-alert__title Warning
-        p.m-alert__text This is a large dismissible warning alert
+      p.m-alert__text This is a dismissible warning alert
+    chi-alert.-m--2(type='banner', color='warning', icon='warning', alert-title="Warning", dismissible)
+      p.m-alert__text This is a dismissible warning alert
+    chi-alert.-m--2(type='banner', color='warning', icon='warning', size='lg', alert-title="Warning", dismissible)
+      p.m-alert__text This is a large dismissible warning alert
   :code(lang="html")
     <!-- Dismissible -->
     <chi-alert type="banner" color="warning" icon="warning" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a dismissible warning alert</p>
-      </div>
+      <p class="m-alert__text">This is a dismissible warning alert</p>
     </chi-alert>
     <!-- Dismissible Titled -->
-    <chi-alert type="banner" color="warning" icon="warning" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a dismissible warning alert</p>
-      </div>
+    <chi-alert type="banner" color="warning" icon="warning" alert-title="Warning" dismissible>
+      <p class="m-alert__text">This is a dismissible warning alert</p>
     </chi-alert>
     <!-- Large Dismissible Titled -->
-    <chi-alert type="banner" color="warning" icon="warning" size="lg" dismissible>
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a large dismissible warning alert</p>
-      </div>
+    <chi-alert type="banner" color="warning" icon="warning" size="lg" alert-title="Warning" dismissible>
+      <p class="m-alert__text">This is a large dismissible warning alert</p>
     </chi-alert>
 
 h4 Actionable
@@ -543,104 +388,68 @@ h4 Default
 .example.-mb--3
   .-p--1
     chi-alert.-m--2(type='toast', icon='circle-info')
-      .m-alert__content
-        p.m-alert__text This is a base alert
+      p.m-alert__text This is a base alert
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       chi-alert.-m--2(type='toast', icon=val, color=type)
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
     <chi-alert type="toast" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
     <chi-alert type="toast" color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
     <chi-alert type="toast" color="danger" icon="circle-warning">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
     <chi-alert type="toast" color="warning" icon="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
     <chi-alert type="toast" color="info" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
     <chi-alert type="toast" color="muted" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Titled
 .example.-mb--3
   .-p--1
-    chi-alert.-m--2(type='toast', icon='circle-info')
-      .m-alert__content
-        p.m-alert__title Base
-        p.m-alert__text This is a base alert
+    chi-alert.-m--2(type='toast', icon='circle-info', alert-title="Base")
+      p.m-alert__text This is a base alert
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(type='toast', color=type, icon=val)
-        .m-alert__content
-          p.m-alert__title= type
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+      chi-alert.-m--2(type='toast', color=type, icon=val, alert-title=type)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   :code(lang="html")
     <!-- Base - No semantic color defined -->
-    <chi-alert type="toast" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Base</p>
-        <p class="m-alert__text">This is a base alert</p>
-      </div>
+    <chi-alert type="toast" icon="circle-info" alert-title="Base">
+      <p class="m-alert__text">This is a base alert</p>
     </chi-alert>
     <!-- Success -->
-    <chi-alert type="toast" icon="circle-check" color="success">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert type="toast" icon="circle-check" color="success" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Danger -->
-    <chi-alert type="toast" color="danger" icon="circle-warning">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Danger</p>
-        <p class="m-alert__text">This is a danger alert</p>
-      </div>
+    <chi-alert type="toast" color="danger" icon="circle-warning" alert-title="Danger">
+      <p class="m-alert__text">This is a danger alert</p>
     </chi-alert>
     <!-- Warning -->
-    <chi-alert type="toast" color="warning" icon="warning">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Warning</p>
-        <p class="m-alert__text">This is a warning alert</p>
-      </div>
+    <chi-alert type="toast" color="warning" icon="warning" alert-title="Warning">
+      <p class="m-alert__text">This is a warning alert</p>
     </chi-alert>
     <!-- Info -->
-    <chi-alert type="toast" color="info" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Info</p>
-        <p class="m-alert__text">This is an info alert</p>
-      </div>
+    <chi-alert type="toast" color="info" icon="circle-info" alert-title="Info">
+      <p class="m-alert__text">This is an info alert</p>
     </chi-alert>
     <!-- Muted -->
-    <chi-alert type="toast" color="muted" icon="circle-info">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Muted</p>
-        <p class="m-alert__text">This is a muted alert</p>
-      </div>
+    <chi-alert type="toast" color="muted" icon="circle-info" alert-title="Muted">
+      <p class="m-alert__text">This is a muted alert</p>
     </chi-alert>
 
 h4 Sizes
@@ -648,67 +457,43 @@ h4 Sizes
   .-p--1
     p.-text--bold.-ml--2 -sm
     chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='sm')
-      .m-alert__content
-        p.m-alert__text This is a small success alert
-    chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='sm')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a small success alert
+      p.m-alert__text This is a small success alert
+    chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='sm', alert-title="Success")
+      p.m-alert__text This is a small success alert
     p.-text--bold.-ml--2 -md (default)
     chi-alert.-m--2(type='toast', color='success', icon='circle-check')
-      .m-alert__content
-        p.m-alert__text This is a success alert
-    chi-alert.-m--2(type='toast', color='success', icon='circle-check')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a success alert
+      p.m-alert__text This is a success alert
+    chi-alert.-m--2(type='toast', color='success', icon='circle-check', alert-title="Success")
+      p.m-alert__text This is a success alert
     p.-text--bold.-ml--2 -lg
     chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='lg')
-      .m-alert__content
-        p.m-alert__text This is a large success alert
-    chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='lg')
-      .m-alert__content
-        p.m-alert__title Success
-        p.m-alert__text This is a large success alert
+      p.m-alert__text This is a large success alert
+    chi-alert.-m--2(type='toast', color='success', icon='circle-check', size='lg', alert-title="Success")
+      p.m-alert__text This is a large success alert
   :code(lang="html")
     <!-- Small -->
     <chi-alert type="toast" color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Small Titled -->
-    <chi-alert type="toast" color="success" icon="circle-check" size="sm">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a small success alert</p>
-      </div>
+    <chi-alert type="toast" color="success" icon="circle-check" size="sm" alert-title="Success">
+      <p class="m-alert__text">This is a small success alert</p>
     </chi-alert>
     <!-- Medium -->
     <chi-alert type="toast" color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Medium Titled -->
-    <chi-alert type="toast" color="success" icon="circle-check">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a success alert</p>
-      </div>
+    <chi-alert type="toast" color="success" icon="circle-check" alert-title="Success">
+      <p class="m-alert__text">This is a success alert</p>
     </chi-alert>
     <!-- Large -->
     <chi-alert type="toast" color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
     <!-- Large Titled -->
-    <chi-alert type="toast" color="success" icon="circle-check" size="lg">
-      <div class="m-alert__content">
-        <p class="m-alert__title">Success</p>
-        <p class="m-alert__text">This is a large success alert</p>
-      </div>
+    <chi-alert type="toast" color="success" icon="circle-check" size="lg" alert-title="Success">
+      <p class="m-alert__text">This is a large success alert</p>
     </chi-alert>
 
 div.a-divider.-my--6.-bt--2

--- a/test/chi/custom-elements/alert-banner.pug
+++ b/test/chi/custom-elements/alert-banner.pug
@@ -8,37 +8,30 @@ each size in ['default', 'sm', 'lg']
   h4 Default / #{size}
   div(class=`test-banner-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type='banner', size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type='banner', size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-${type}-${size}`)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   h4 Centered / #{size}
   div(class=`test-banner-center-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type='banner', center, size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} centered ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type='banner', center, size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-center-${type}-${size}`)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} centered ${type} alert`
   h4 Dismissible / #{size}
   div(class=`test-banner-dismissible-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type="banner" dismissible, size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__text= `This is a dismissible ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type="banner" dismissible, size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-dismissible-${type}-${size}`)
+        p.m-alert__text= `This is a dismissible ${type} alert`
   h4 Borderless / #{size}
   div(class=`test-banner-borderless-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type="banner", borderless, size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__text= `This is a borderless ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type="banner", borderless, size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-borderless-${type}-${size}`)
+        p.m-alert__text= `This is a borderless ${type} alert`
   h4 Rounded / #{size}
   div(class=`test-banner-rounded-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type="banner", rounded, size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__text= `This is a rounded ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type="banner", rounded, size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-rounded-${type}-${size}`)
+        p.m-alert__text= `This is a rounded ${type} alert`
   h4 Titled / #{size}
   div(class=`test-banner-titled-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(color=type, icon=val, type="banner", size=`${size === 'default' ? '' : size}`)
-        .m-alert__content
-          p.m-alert__title= `${type}`
-          p.m-alert__text= `This is a titled ${type} alert`
+      chi-alert.-m--2(color=type, icon=val, type="banner", size=`${size === 'default' ? '' : size}`, data-cy=`alert-banner-titled-${type}-${size}`, alert-title=type)
+        p.m-alert__text= `This is a titled ${type} alert`

--- a/test/chi/custom-elements/alert-bubble.pug
+++ b/test/chi/custom-elements/alert-bubble.pug
@@ -9,39 +9,32 @@ each size in ['default', 'sm', 'lg']
   div(class=`test-bubble-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       .-m--2
-        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`)
-          .m-alert__content
-            p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`, data-cy=`alert-bubble-${type}-${size}`)
+          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
   h4 Centered / #{size}
   div(class=`test-bubble-center-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       .-m--2
-        chi-alert(color=type, icon=val, center, size=`${size === 'default' ? '' : size}`)
-          .m-alert__content
-            p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} centered ${type} alert`
+        chi-alert(color=type, icon=val, center, size=`${size === 'default' ? '' : size}`, data-cy=`alert-bubble-center-${type}-${size}`)
+          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} centered ${type} alert`
   h4 Dismissible / #{size}
   div(class=`test-bubble-dismissible-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       .-m--2
-        chi-alert(color=type, icon=val, dismissible, size=`${size === 'default' ? '' : size}`)
-          .m-alert__content
-            p.m-alert__text= `This is a dismissible ${type} alert`
+        chi-alert(color=type, icon=val, dismissible, size=`${size === 'default' ? '' : size}`, data-cy=`alert-bubble-dismissible-${type}-${size}`)
+          p.m-alert__text= `This is a dismissible ${type} alert`
   h4 Titled / #{size}
   div(class=`test-bubble-titled-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       .-m--2
-        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`)
-          .m-alert__content
-            p.m-alert__title=`${type}`
-            p.m-alert__text= `This is a titled ${type} alert`
+        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`, data-cy=`alert-bubble-titled-${type}-${size}`, alert-title=type)
+          p.m-alert__text= `This is a titled ${type} alert`
   h4 Actionable / #{size}
   div(class=`test-bubble-actionable-${size} -w--100`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
       .-m--2
-        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`)
-          .m-alert__content
-            p.m-alert__title=`${type}`
-            p.m-alert__text= `This is a ${size} ${type} actionable alert`
-            div.m-alert__actions
-              button.a-btn.-dark.-outline(class=`-${size}`) Secondary action
-              button.a-btn.-primary(class=`-${size}`) Primary action
+        chi-alert(color=type, icon=val, size=`${size === 'default' ? '' : size}`, data-cy=`alert-bubble-actionable-${type}-${size}`, alert-title=type)
+          p.m-alert__text= `This is a ${size} ${type} actionable alert`
+          div.m-alert__actions
+            button.a-btn.-dark.-outline(class=`-${size}`) Secondary action
+            button.a-btn.-primary(class=`-${size}`) Primary action

--- a/test/chi/custom-elements/alert-toast.pug
+++ b/test/chi/custom-elements/alert-toast.pug
@@ -8,14 +8,11 @@ each size in ['default', 'sm', 'lg']
   h4 Default / #{size}
   div(class=`test-toast-${size}`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(type='toast', size=`${size === 'default' ? '' : size}`, icon=val, color=type)
-        .m-alert__content
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
+      chi-alert.-m--2(type='toast', size=`${size === 'default' ? '' : size}`, icon=val, color=type, data-cy=`alert-toast-${type}-${size}`)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} alert`
 
   h4 Titled /  #{size}
   div(class=`test-toast-titled-${size}`)
     each val, type in {success:'circle-check', danger:'circle-warning', warning:'warning', info:'circle-info', muted:'circle-info'}
-      chi-alert.-m--2(type='toast', size=`${size === 'default' ? '' : size}`, color=type, icon=val)
-        .m-alert__content
-          p.m-alert__title= type
-          p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} toast alert`
+      chi-alert.-m--2(type='toast', size=`${size === 'default' ? '' : size}`, color=type, icon=val, alert-title=type)
+        p.m-alert__text=`This is ${type === 'info' ? 'an' : 'a'} ${type} toast alert`


### PR DESCRIPTION
- Added support of `alert-title=""` attribute (I tried to make it `title=""` but looks like the word "title" is reserved) thoughts about the naming? @mattnickles @jllr
- Fixed Cypress tests
- Added support of creating `m-alert__content` automatically (to remove m-alert__content from markup)
- Updated Alert custom element documentation page